### PR TITLE
#1 - Add page icon

### DIFF
--- a/src/class-table.php
+++ b/src/class-table.php
@@ -36,6 +36,9 @@ class Table extends \WP_List_Table {
 			}
 
 			$post_type_object = get_post_type_object( $post_type );
+			if( $post_type === 'page' ) {
+				$post_type_object->menu_icon = 'dashicons-admin-page';
+			}
 			$menu_icon = empty( $post_type_object->menu_icon ) ? 'dashicons-admin-post' : $post_type_object->menu_icon;
 
 			$links = $submenu[$key];


### PR DESCRIPTION
'page' post type object does not have a `menu_icon` property. Fixes this issue. 

Maybe fix other post types (attachment) if they can be moved to the menu.